### PR TITLE
Add since and description params for annotation

### DIFF
--- a/Annotation/Deprecated.php
+++ b/Annotation/Deprecated.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Shopping\ApiTKDeprecationBundle\Annotation;
 
+use DateTime;
+
 /**
  * Class Deprecated
  *
@@ -12,9 +14,19 @@ namespace Shopping\ApiTKDeprecationBundle\Annotation;
 class Deprecated
 {
     /**
-     * @var \DateTime|null
+     * @var DateTime|null
      */
-    private $removedAfter = null;
+    private $removedAfter;
+
+    /**
+     * @var DateTime|null
+     */
+    private $since;
+
+    /**
+     * @var string|null
+     */
+    private $description;
 
     /**
      * @var bool
@@ -27,21 +39,42 @@ class Deprecated
     public function __construct($options = null)
     {
         if (is_array($options)) {
-            $this->removedAfter = isset($options['removedAfter']) ? new \DateTime($options['removedAfter']) : null;
+            $this->removedAfter = isset($options['removedAfter']) ? new DateTime($options['removedAfter']) : null;
+            $this->since = isset($options['since']) ? new DateTime($options['since']) : null;
+            $this->description = $options['description'] ?? null;
             $this->hideInDoc = $options['hideInDoc'] ?? false;
         }
     }
 
     /**
-     * @return \DateTime|null
+     * @return DateTime|null
      */
-    public function getRemovedAfter(): ?\DateTime
+    public function getRemovedAfter(): ?DateTime
     {
         return $this->removedAfter;
     }
 
+    /**
+     * @return bool
+     */
     public function isHiddenInDoc(): bool
     {
         return $this->hideInDoc;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getSince(): ?DateTime
+    {
+        return $this->since;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
     }
 }

--- a/Describer/AnnotationDescriber.php
+++ b/Describer/AnnotationDescriber.php
@@ -39,28 +39,20 @@ class AnnotationDescriber extends AbstractDescriber
 
             $deprecatedString = '!!! DEPRECATED !!! ';
 
-            $headerInformation = [
-                'x-api-deprecated' => [
-                    'description' => 'Flag for endpoint deprecation',
-                    'type' => 'string ("deprecated")',
-                ]
-            ];
-
             $removedString = '';
             if ($annotation->getRemovedAfter()) {
-                $removedString = 'REMOVED AT ' . $annotation->getRemovedAfter()->format('Y-m-d') . ' OR LATER !!! ';
-
-                $headerInformation['x-apitk-deprecated-removed-at'] = [
-                    'description' => 'The time when the endpoint start being deprecated',
-                    'type' => 'date ("Y-m-d")',
-                ];
+                $removedString .= 'REMOVED AT '
+                    . $annotation->getRemovedAfter()->format('Y-m-d')
+                    . ' OR LATER !!! ';
             }
-
-            $response = $operation->getResponses()->get(200);
-            $response->merge(['headers' => $headerInformation]);
-
-            $operation->getResponses()->set(200, $response);
-
+            if ($annotation->getSince()) {
+                $removedString .= 'Deprecated since '
+                    . $annotation->getSince()->format('Y-m-d')
+                    . ' ';
+            }
+            if (!empty($annotation->getDescription())) {
+                $removedString .= $annotation->getDescription() . ' ';
+            }
 
             /** @noinspection PhpToStringImplementationInspection */
             $operation->setSummary($deprecatedString . $removedString);

--- a/EventListener/DeprecationListener.php
+++ b/EventListener/DeprecationListener.php
@@ -40,7 +40,7 @@ class DeprecationListener
         $this->headerInformation = $headerInformation;
     }
 
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelController(FilterControllerEvent $event): void
     {
         //Only transform on original action
         if (!$this->masterRequest) {
@@ -57,9 +57,15 @@ class DeprecationListener
             return;
         }
 
-        $this->headerInformation->add('deprecated', 'deprecated');
+        $this->headerInformation->add('deprecated', $annotation->getDescription() ?? 'deprecated');
         if ($annotation->getRemovedAfter()) {
-            $this->headerInformation->add('deprecated-removed-at', $annotation->getRemovedAfter()->format('Y-m-d'));
+            $this->headerInformation->add(
+                'deprecated-removed-at',
+                $annotation->getRemovedAfter()->format('Y-m-d')
+            );
+        }
+        if ($annotation->getSince()) {
+            $this->headerInformation->add('deprecated-since', $annotation->getSince()->format('Y-m-d'));
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@ use Shopping\ApiTKDeprecationBundle\Annotation\Deprecated;
  * @Rest\Get("/v2/users")
  * @Rest\View()
  *
- * @Deprecated(removedAfter="2018-10-09")
+ * @Deprecated(removedAfter="2018-10-09", since="2018-07-01", description="use /v3/users instead")
  
  * @param User[] $users
  * @return User[]
  */
  ```
  A notice is displayed inside the swagger documentation and a new response header
- `x-apitk-deprecated: deprecated` and `x-apitk-deprecated-removed-at: 2018-10-09` (if a date was set)
+ `x-apitk-deprecated: use /v3/users instead`,
+ `x-apitk-deprecated-removed-at: 2018-10-09` (if a date was set),
+ `x-apitk-deprecated-since: 2018-07-01` (if a date was set)
  will be sent to the client.
+
+All annotation arguments are optional, so feel free to use `@Deprecated` only. In this case
+all clients will receive a `x-apitk-deprecated: deprecated` response header. The header's 
+value may be overridden by providing the `description` argument as shown above.
 
 If you want to hide a certain endpoint from the docs, use the `hideFromDocs=true` parameter in
 the `Deprecated` annotation. The corresponding action then will not be shown.


### PR DESCRIPTION
Users can now provide `description` and `since` arguments for a given `@Deprecated` annotation.

```
@Deprecated(since="2019-10-08", description="use /api/foobar instead")
```

will generate the following response headers:

```
x-apitk-deprecated: use /api/foobar instead
x-apitk-deprecated-since: 2019-10-08
```

Both parameters are optional. In case no `description` is provided, the default value of `deprecated` will be used (= current behaviour).

![Bildschirmfoto 2019-10-08 um 08 55 24](https://user-images.githubusercontent.com/690188/66378490-d1377080-e9b3-11e9-8825-28d2b0f0f015.png)
